### PR TITLE
Changes interface to class type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
-import { number } from "bitcoinjs-lib/types/script";
-
-export { TxOutput, Transaction } from "bitcoinjs-lib";
+export { TxOutput, Transaction, Network } from "bitcoinjs-lib";
 
 export interface AddressInformation {
     address: string;
@@ -89,7 +87,7 @@ type BtcTransactionHelperConfig = {
     txFee?: number;
 }
 
-export default class BtcTransactionHelper {
+export class BtcTransactionHelper {
     constructor(config: BtcTransactionHelperConfig);
     generateBtcAddress(type: AddressType): Promise<AddressInformation>;
     generateMultisigAddress(signerSize: number, requiredSigners: number, type: AddressType): Promise<MultisigAddressInformation>;
@@ -108,3 +106,11 @@ export default class BtcTransactionHelper {
     getBlockHeader(blockHash: string, jsonEncoded: boolean = true): Promise<BlockHeader | string>;
     getTransactionsInMempool(verbose: boolean = false): Promise<string[] | MempoolTransactions>;
 }
+
+export class BtcTransactionHelperException {
+    stack: string;
+    constructor(message: string, error: Error);
+}
+
+export const btcToSatoshis = (amount: number) => number;
+export const satoshisToBtc = (amount: amount) => number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export interface MempoolTransactions {
     [txId: string]: MempoolTransaction
 }
 
-export default interface BtcTransactionHelper {
+export default class BtcTransactionHelper {
     generateBtcAddress(type: AddressType): Promise<AddressInformation>;
     generateMultisigAddress(signerSize: number, requiredSigners: number, type: AddressType): Promise<MultisigAddressInformation>;
     selectSpendableUTXOsFromAddress(address: string, amountInBtc: number): Promise<SpendableUtxosInformation>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { number } from "bitcoinjs-lib/types/script";
+
 export { TxOutput, Transaction } from "bitcoinjs-lib";
 
 export interface AddressInformation {
@@ -77,7 +79,18 @@ export interface MempoolTransactions {
     [txId: string]: MempoolTransaction
 }
 
+type BtcTransactionHelperConfig = {
+    host: string;
+    port: number;
+    user: string;
+    pass: string;
+    network: string;
+    timeout: number;
+    txFee: number;
+}
+
 export default class BtcTransactionHelper {
+    constructor(config: BtcTransactionHelperConfig);
     generateBtcAddress(type: AddressType): Promise<AddressInformation>;
     generateMultisigAddress(signerSize: number, requiredSigners: number, type: AddressType): Promise<MultisigAddressInformation>;
     selectSpendableUTXOsFromAddress(address: string, amountInBtc: number): Promise<SpendableUtxosInformation>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,13 +80,13 @@ export interface MempoolTransactions {
 }
 
 type BtcTransactionHelperConfig = {
-    host: string;
-    port: number;
-    user: string;
-    pass: string;
-    network: string;
-    timeout: number;
-    txFee: number;
+    host?: string;
+    port?: number;
+    user?: string;
+    pass?: string;
+    network?: string;
+    timeout?: number;
+    txFee?: number;
 }
 
 export default class BtcTransactionHelper {


### PR DESCRIPTION
This pr includes changes to the `index.d.ts` file. 
It turns out that the returning types in the `index.d.ts` did not really match with what the `index.js` file is returning.

The `index.d.ts` was considering the `BtcTransactionHelper` type to be imported by default. But in reality, the `index.js` file is not importing that file by default, but rather inside an object with other utilities.

While using this library in a Typescript environment, the exported/imported types did not match. So this pr is handling that and now the `index.d.ts` is really expressing what the `index.js` is really exporting.
